### PR TITLE
feat: escape path and support 'src' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@
 curl https://adobeioruntime.net/api/v1/web/helix/helix-services/data-embed@v1/https://blogs.adobe.com/psirt/?feed=atom
 ```
 
+While the above is simple to type, it is more safe to escape the url and optionally pass it as `src` query parameter:
+
+```bash
+curl https://adobeioruntime.net/api/v1/web/helix/helix-services/data-embed@v1/https%3A%2F%2Fblogs.adobe.com%2Fpsirt%2F%3Ffeed%3Datom
+```
+
+or
+
+```bash
+curl https://adobeioruntime.net/api/v1/web/helix/helix-services/data-embed@v1?src=https%3A%2F%2Fblogs.adobe.com%2Fpsirt%2F%3Ffeed%3Datom
+```
+
 ### Data Sources
 
 Supported data sources include:

--- a/src/data-source.js
+++ b/src/data-source.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const querystring = require('querystring');
+
+/**
+ * Analyses the params and extracts the data source, which is specified by a `src` param.
+ * For backward compatibility, the source can also be added as path, either escaped or unescaped.
+ *
+ * @param {string} params the openwhisk action params
+ * @return {URL} the extracted data source or null
+ */
+function dataSource(params) {
+  const { __ow_path: path = '', src = '' } = params;
+  if (!path) {
+    if (!src.startsWith('https://')) {
+      return null;
+    }
+    return new URL(params.src);
+  }
+
+  // expect the _ow_path to start with /https:// or /https%3a%2f%2f
+  if (path.startsWith('/https%3A%2F%2F')) {
+    return new URL(decodeURIComponent(path.substring(1)));
+  }
+  if (!path.startsWith('/https://')) {
+    return null;
+  }
+  const url = new URL(path.substring(1));
+
+  if (!params.__ow_query) {
+    // reconstruct __ow_query
+    Object.keys(params)
+      .filter((key) => !/^[A-Z]+_[A-Z]+/.test(key))
+      .filter((key) => key !== 'api')
+      .filter((key) => !/^__ow_/.test(key))
+      .forEach((key) => {
+        url.searchParams.append(key, params[key]);
+      });
+  } else {
+    // else add it to the url
+    Object.entries(querystring.parse(params.__ow_query)).forEach(([key, value]) => {
+      url.searchParams.append(key, value);
+    });
+  }
+  return url;
+}
+
+module.exports = dataSource;

--- a/src/index.js
+++ b/src/index.js
@@ -16,37 +16,22 @@ const { epsagon } = require('@adobe/helix-epsagon');
 const embed = require('./embed');
 const { loadquerystring } = require('./querybuilder/url');
 const { createfilter } = require('./querybuilder/filter');
+const dataSource = require('./data-source.js');
 
 async function main(params) {
   /* istanbul ignore next */
   const { __ow_logger: log = console } = params;
-  if (!params.__ow_path) {
+  const url = dataSource((params));
+  if (!url) {
     return {
       statusCode: 400,
-      body: 'Expecting a path',
+      body: 'Expecting a datasource',
     };
   }
 
-  if (!params.__ow_query) {
-    // reconstruct __ow_query
-    const query = Object.keys(params)
-      .filter((key) => !/^[A-Z]+_[A-Z]+/.test(key))
-      .filter((key) => key !== 'api')
-      .filter((key) => !/^__ow_/.test(key))
-      .reduce((pv, cv) => {
-        if (pv) {
-          return `${pv}&${cv}=${params[cv]}`;
-        }
-        return `${cv}=${params[cv]}`;
-      }, '');
-    // eslint-disable-next-line no-param-reassign
-    params.__ow_query = query;
-  }
-  const url = `${params.__ow_path.substring(1)}?${params.__ow_query || ''}`;
-
-  const qbquery = loadquerystring(params.__ow_query, 'hlx_');
+  const qbquery = loadquerystring(url.search.substring(1), 'hlx_');
   const filter = createfilter(qbquery);
-  const result = await embed(url, params, log);
+  const result = await embed(url.toString(), params, log);
 
   return {
     ...result,

--- a/test/data-source.test.js
+++ b/test/data-source.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const querystring = require('querystring');
+const dataSource = require('../src/data-source.js');
+
+describe('Data Source Tests', () => {
+  it('returns null for no path or src', () => {
+    assert.equal(dataSource({}), null);
+  });
+
+  it('rejects paths not starting with https://', () => {
+    assert.equal(dataSource({
+    }),
+    null);
+  });
+
+  it('rejects escaped paths not starting with https://', () => {
+    assert.equal(dataSource({
+      __ow_path: `/${querystring.escape('http://example.com')}`,
+    }),
+    null);
+  });
+
+  it('rejects src parameters not starting with https://', () => {
+    assert.equal(dataSource({
+      src: '/http://example.com',
+    }),
+    null);
+  });
+
+  it('returns data source for `src` parameter', () => {
+    assert.equal(dataSource({
+      src: 'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with no query', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with query', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500',
+      __ow_query: 'a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with query in params', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500',
+      a: 1,
+      b: 2,
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for escaped path', () => {
+    assert.equal(dataSource({
+      __ow_path: `/${querystring.escape('https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2')}`,
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ describe('Integration Tests', () => {
       'Content-Type': 'application/json',
     };
     const { body, headers, statusCode } = await main({
-      __ow_path: 'https://example.com/_query/run-query/error500',
+      __ow_path: '/https://example.com/_query/run-query/error500',
       __ow_query: 'fromMins=1000&toMins=0',
     });
 


### PR DESCRIPTION
fixes #11

- encapsulates the extraction in own utility
- supports escaped `__ow_paths`
- supports `params.src` as data source