### PR TITLE
feat(data): add sheet addressing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For more, see the [API documentation](docs/API.md).
 - The sheet inside an Excel workbook or Google spreadsheet can be addressed using the `sheet` parameter. 
 - Only sheets having the `helix-` prefix can be addressed.
 - If the workbook or spreadsheet does not have any `helix-` prefixed sheets, the first sheet is returned.
-- By default, the _used ranged_ of the selected sheet is returned.
+- By default, the _used range_ of the selected sheet is returned.
 - For excel, A table can be addressed using the `table` request parameter, which can be a table name or an index. For example, `table=Table1` will return the table with the name `Table1`, `table=1` will return the second table in the sheet.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Furthermore, it is possible to limit the result set using `hlx_p.limit` and page
 
 For more, see the [API documentation](docs/API.md).
 
+## Working with Excel and Google Sheets
+
+- The sheet inside an Excel workbook or Google spreadsheet can be addressed using the `sheet` parameter. 
+- Only sheets having the `helix-` prefix can be addressed.
+- If the workbook or spreadsheet does not have any `helix-` prefixed sheets, the first sheet is returned.
+- By default, the _used ranged_ of the selected sheet is returned.
+- For excel, A table can be addressed using the `table` request parameter, which can be a table name or an index. For example, `table=Table1` will return the table with the name `Table1`, `table=1` will return the second table in the sheet.
+
 ## Development
 
 ### Deploying Helix Data Embed

--- a/test/excel.integration.test.js
+++ b/test/excel.integration.test.js
@@ -17,49 +17,118 @@ const { main } = require('../src/index');
 
 require('dotenv').config();
 
+const condition = condit.hasenv('AZURE_WORD2MD_CLIENT_ID', 'AZURE_HELIX_USER', 'AZURE_HELIX_PASSWORD');
+
+const DATA_COUNTRIES = [{ Country: 'Japan', Code: 'JP', Number: 3 },
+  { Country: 'Germany', Code: 'DE', Number: 5 },
+  { Country: 'USA', Code: 'US', Number: 7 },
+  { Country: 'Switzerland', Code: 'CH', Number: 27 },
+  { Country: 'France', Code: 'FR', Number: 99 },
+  { Country: 'Australia', Code: 'AUS', Number: 12 }];
+
 describe('Excel Integration Test', () => {
-  condit('Retrieves Excel Spreadsheet without tables', condit.hasenv('AZURE_WORD2MD_CLIENT_ID', 'AZURE_HELIX_USER', 'AZURE_HELIX_PASSWORD'), async () => {
+  condit('Excel Spreadsheet without helix-default sheet returns 404', condition, async () => {
     const result = await main({
       __ow_logger: console,
-      __ow_path: '/https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx',
-      share: 'Edoi88tLKLpDsKzSfL-pcJYB2lIo7UKooYWnjm3w2WRrsA',
-      email: 'helix@adobe.com',
-      e: 'tD623x',
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/data-embed-no-default.xlsx?d=wf80aa1d65efb4e41bd16ba3ca0a4564b&csf=1&web=1&e=9WnXzf',
       AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
       AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
       AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
     });
-    assert.equal(result.statusCode, 200);
-    assert.equal(result.body.length, 3);
+    assert.equal(result.statusCode, 404);
   }).timeout(15000);
 
-  condit('Retrieves Excel Spreadsheet with tables', condit.hasenv('AZURE_WORD2MD_CLIENT_ID', 'AZURE_HELIX_USER', 'AZURE_HELIX_PASSWORD'), async () => {
+  condit('Excel Spreadsheet without helix-default but sheet params', condition, async () => {
     const result = await main({
       __ow_logger: console,
-      __ow_path: '/https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx',
-      share: 'Edz_l4D0BghJjLkIfyZCB7sBLaBhySyT5An7fPHVS6CFuA',
-      email: 'helix@adobe.com',
-      e: 'e5ziwf',
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/data-embed-no-default.xlsx?d=wf80aa1d65efb4e41bd16ba3ca0a4564b&csf=1&web=1&e=9WnXzf',
+      sheet: 'countries',
       AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
       AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
       AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
     });
     assert.equal(result.statusCode, 200);
-    assert.equal(result.body.length, 20);
+    assert.deepEqual(result.body, DATA_COUNTRIES);
   }).timeout(15000);
 
-  condit('Retrieves Excel Spreadsheet via drive uri', condit.hasenv('AZURE_WORD2MD_CLIENT_ID', 'AZURE_HELIX_USER', 'AZURE_HELIX_PASSWORD'), async () => {
+  condit('Excel Spreadsheet without helix returns first sheet', condition, async () => {
     const result = await main({
       __ow_logger: console,
-      src: 'onedrive:/drives/b!2nFK7YhvL0yLgH3l_6DPvdBErfBlFFRPphB3wsFazXGX6gDR8muPTo89wY6LZLgv/items/01YELWHJW476LYB5AGBBEYZOIIP4TEEB53',
-      share: 'Edz_l4D0BghJjLkIfyZCB7sBLaBhySyT5An7fPHVS6CFuA',
-      email: 'helix@adobe.com',
-      e: 'e5ziwf',
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/data-embed-no-helix.xlsx?d=w88ace0003b6847a48b6bb84b79a5b72b&csf=1&web=1&e=Sg8lKt',
       AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
       AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
       AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
     });
     assert.equal(result.statusCode, 200);
-    assert.equal(result.body.length, 20);
+    assert.deepEqual(result.body, [{ Country: 'Japan', Code: 'JP', Number: 81 }]);
+  }).timeout(15000);
+
+  condit('Excel Spreadsheet without helix-default but sheet params Unicode', condition, async () => {
+    const result = await main({
+      __ow_logger: console,
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a',
+      sheet: '日本',
+      AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
+      AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
+      AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
+    });
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, [{
+      Code: 'JP',
+      Country: 'Japan',
+      Number: 3,
+    }]);
+  }).timeout(15000);
+
+  condit('Retrieves Excel Spreadsheet with helix-default (range)', condition, async () => {
+    const result = await main({
+      __ow_logger: console,
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a',
+      AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
+      AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
+      AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
+    });
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, DATA_COUNTRIES);
+  }).timeout(15000);
+
+  condit('Retrieves Excel Spreadsheet with tables and table name', condition, async () => {
+    const result = await main({
+      __ow_logger: console,
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a',
+      sheet: 'tables',
+      table: 'Table1',
+      AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
+      AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
+      AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
+    });
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, [{ A: 112, B: 224, C: 135 }, { A: 2244, B: 234, C: 53 }]);
+  }).timeout(15000);
+
+  condit('Retrieves Excel Spreadsheet with tables and table index', condition, async () => {
+    const result = await main({
+      __ow_logger: console,
+      src: 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a',
+      sheet: 'tables',
+      table: 1,
+      AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
+      AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
+      AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
+    });
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, [{ X: 111, Y: 222, Z: 333 }, { X: 444, Y: 555, Z: 666 }]);
+  }).timeout(15000);
+
+  condit('Retrieves Excel Spreadsheet via drive uri', condition, async () => {
+    const result = await main({
+      __ow_logger: console,
+      src: 'onedrive:/drives/b!DyVXacYnlkm_17hZL307Me9vzRzaKwZCpVMBYbPOKaVT_gD5WmlHRbC-PCpiwGPx/items/012VWERI7U74IWSKVFH5F3QBLA3B4FVX5D',
+      AZURE_WORD2MD_CLIENT_ID: process.env.AZURE_WORD2MD_CLIENT_ID,
+      AZURE_HELIX_USER: process.env.AZURE_HELIX_USER,
+      AZURE_HELIX_PASSWORD: process.env.AZURE_HELIX_PASSWORD,
+    });
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, DATA_COUNTRIES);
   }).timeout(15000);
 });

--- a/test/fixtures/book-without-default.js
+++ b/test/fixtures/book-without-default.js
@@ -18,33 +18,15 @@ const data = [
   ['France', 'FR', 99],
 ];
 
-const data2 = [
-  ['Country', 'Code', 'Number'],
-  ['Japan', 'JP', 81],
-];
-
-const tables = [{
-  name: 'Table1',
-  headerNames: data[0],
-  rows: data.slice(1),
-}];
+const tables = [];
 
 const namedItems = [];
 
 module.exports = {
-  name: 'book-with-tables',
+  name: 'book-without-default',
   tables,
   sheets: [{
-    name: 'Sheet1',
-    tables: [],
-    namedItems,
-    usedRange: {
-      address: 'Sheet1!A1:B4',
-      addressLocal: 'A1:B4',
-      values: data2,
-    },
-  }, {
-    name: 'helix-default',
+    name: 'helix-countries',
     tables,
     namedItems,
     usedRange: {

--- a/test/fixtures/book-without-helix.js
+++ b/test/fixtures/book-without-helix.js
@@ -18,33 +18,15 @@ const data = [
   ['France', 'FR', 99],
 ];
 
-const data2 = [
-  ['Country', 'Code', 'Number'],
-  ['Japan', 'JP', 81],
-];
-
-const tables = [{
-  name: 'Table1',
-  headerNames: data[0],
-  rows: data.slice(1),
-}];
+const tables = [];
 
 const namedItems = [];
 
 module.exports = {
-  name: 'book-with-tables',
+  name: 'book-without-helix',
   tables,
   sheets: [{
     name: 'Sheet1',
-    tables: [],
-    namedItems,
-    usedRange: {
-      address: 'Sheet1!A1:B4',
-      addressLocal: 'A1:B4',
-      values: data2,
-    },
-  }, {
-    name: 'helix-default',
     tables,
     namedItems,
     usedRange: {

--- a/test/fixtures/book-without-tables.js
+++ b/test/fixtures/book-without-tables.js
@@ -23,10 +23,10 @@ const tables = [];
 const namedItems = [];
 
 module.exports = {
-  name: 'book-with-tables',
+  name: 'book-without-tables',
   tables,
   sheets: [{
-    name: 'Sheet1',
+    name: 'helix-default',
     tables,
     namedItems,
     usedRange: {

--- a/test/google.test.js
+++ b/test/google.test.js
@@ -31,6 +31,84 @@ class MockOAuth2 {
   }
 }
 
+const TEST_SHEETS_1 = {
+  data: {
+    spreadsheetId: '1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k',
+    properties: {
+      title: 'Autos',
+      locale: 'en_US',
+      autoRecalc: 'ON_CHANGE',
+      timeZone: 'Europe/Paris',
+      defaultFormat: {
+        backgroundColor: { red: 1, green: 1, blue: 1 },
+        padding: { right: 3, left: 3 },
+        verticalAlignment: 'BOTTOM',
+        wrapStrategy: 'LEGACY_WRAP',
+        textFormat: {
+          foregroundColor: {}, fontFamily: 'arial,sans,sans-serif', fontSize: 10, bold: false, italic: false, strikethrough: false, underline: false, foregroundColorStyle: { rgbColor: {} },
+        },
+        backgroundColorStyle: { rgbColor: { red: 1, green: 1, blue: 1 } },
+      },
+    },
+    sheets: [{
+      properties: {
+        sheetId: 0, title: 'helix-default', index: 0, sheetType: 'GRID', gridProperties: { rowCount: 92, columnCount: 20, frozenRowCount: 1 },
+      },
+    }],
+    spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit',
+  },
+};
+
+const TEST_SHEETS_2 = {
+  data: {
+    spreadsheetId: '2222222222222222222',
+    properties: {
+      title: 'Autos',
+    },
+    sheets: [{
+      properties: {
+        sheetId: 0, title: 'Sheet1', index: 0, sheetType: 'GRID', gridProperties: { rowCount: 92, columnCount: 20, frozenRowCount: 1 },
+      },
+    }],
+  },
+};
+
+const TEST_SHEETS_3 = {
+  data: {
+    spreadsheetId: '3333333333333333333',
+    properties: {
+      title: 'Autos',
+    },
+    sheets: [{
+      properties: {
+        sheetId: 0, title: 'helix-countries', index: 0, sheetType: 'GRID', gridProperties: { rowCount: 92, columnCount: 20, frozenRowCount: 1 },
+      },
+    }],
+  },
+};
+
+const TEST_VALUES_1 = {
+  data: { range: 'helix-default!A1:T92', majorDimension: 'ROWS', values: [['Hersteller', 'Modell', 'Preis', 'Verbrauch', 'Kofferraum', 'Preis2', 'Verbrauch pro Jahr', 'Gesamtkosten'], ['Hyundai', 'Trajet', 23000, 7.2, 304, 1.1, 5976, 28976, 'Klapptüren', 'Hässlich wie die Nacht'], ['Ford', 'Galaxy Ambiente', 24400, 10.1, 330, 1.3, 8383, 32783, '193 km/h'], ['Fiat', 'Ulysse', 25200, 9.2, 324, 1.3, 7635.999999999999, 32836, 'Schiebetüren'], ['Citroën', 'C8', 25400, 9.1, 324, 1.3, 7553, 32953, 'Schiebetüren'], ['Peugeot', '807 2.0', 25450, 9.1, 324, 1.3, 7553, 33003, 'Schiebetüren'], ['Renault', 'Espace 2.0 Advantage', 25500, 9.4, 291, 1.3, 7802, 33302, 'kleiner Kofferraum'], ['Chrysler', 'Voyager Family', 25900, 10.1, 660, 1.3, 8383, 34283, 'Gegenübersitzen'], ['VW', 'Multivan Startline', 29000, 8, 664, 1.3, 6640, 35640, 'Gegenübersitzen'], ['Lancia', 'Phedra', 30900, 6.9, 324, 1.1, 5727, 36627], ['VW', 'Sharan 2.0', 29300, 9.4, 1200, 1.3, 7802, 37102], ['Mercedes-Benz', 'Viano Lang', 33150, 8.9, 730, 1.1, 7387, 40537], [], ['Hyundai', 'H-1 Travel', 20400, 8.3, '', 1.1, 6889.000000000001, 27289], ['Ford', 'Transit Cityline', 19611, 7, '', 1.1, 5810, 25421], ['Opel', 'Vivaro', 19660, 7.7, '', 1.1, 6391, 26051], ['Renault', 'Trafic', '', '', '', 1.1, 0, 0], ['Nissan', 'Primastar', '', '', '', 1.1, 0, 0], ['Citroën', 'Jumper', '', '', '', 1.1, 0, 0], ['Peugeot', 'Boxer', 19490, 7, '', 1.1, 5810, 25300], ['Fiat', 'Ducato', 19390, 7.3, '', 1.1, 6059, 25449]] },
+};
+const TEST_VALUES_2 = {
+  data: { range: 'Sheet1!A1:B4', majorDimension: 'ROWS', values: [['Country', 'Code', 'Number'], ['Japan', 'JP', '81']] },
+};
+
+const TEST_VALUES_3 = {
+  data: { range: 'helix-countries!A1:B4', majorDimension: 'ROWS', values: [['Country', 'Code', 'Number'], ['Switzerland', 'CH', '41']] },
+};
+
+const TEST_SHEETS = {
+  '1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k': TEST_SHEETS_1,
+  '2222222222222222222': TEST_SHEETS_2,
+  '3333333333333333333': TEST_SHEETS_3,
+};
+const TEST_VALUES = {
+  '1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k': TEST_VALUES_1,
+  '2222222222222222222': TEST_VALUES_2,
+  '3333333333333333333': TEST_VALUES_3,
+};
+
 describe('Google Sheets Tests (mocked)', () => {
   const { extract } = proxyquire('../src/matchers/google.js', {
     googleapis: {
@@ -40,37 +118,9 @@ describe('Google Sheets Tests (mocked)', () => {
         },
         sheets: () => ({
           spreadsheets: {
-            get: () => ({
-              data: {
-                spreadsheetId: '1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k',
-                properties: {
-                  title: 'Autos',
-                  locale: 'en_US',
-                  autoRecalc: 'ON_CHANGE',
-                  timeZone: 'Europe/Paris',
-                  defaultFormat: {
-                    backgroundColor: { red: 1, green: 1, blue: 1 },
-                    padding: { right: 3, left: 3 },
-                    verticalAlignment: 'BOTTOM',
-                    wrapStrategy: 'LEGACY_WRAP',
-                    textFormat: {
-                      foregroundColor: {}, fontFamily: 'arial,sans,sans-serif', fontSize: 10, bold: false, italic: false, strikethrough: false, underline: false, foregroundColorStyle: { rgbColor: {} },
-                    },
-                    backgroundColorStyle: { rgbColor: { red: 1, green: 1, blue: 1 } },
-                  },
-                },
-                sheets: [{
-                  properties: {
-                    sheetId: 0, title: 'Sheet1', index: 0, sheetType: 'GRID', gridProperties: { rowCount: 92, columnCount: 20, frozenRowCount: 1 },
-                  },
-                }],
-                spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit',
-              },
-            }),
+            get: ({ spreadsheetId }) => (TEST_SHEETS[spreadsheetId]),
             values: {
-              get: () => ({
-                data: { range: 'Sheet1!A1:T92', majorDimension: 'ROWS', values: [['Hersteller', 'Modell', 'Preis', 'Verbrauch', 'Kofferraum', 'Preis2', 'Verbrauch pro Jahr', 'Gesamtkosten'], ['Hyundai', 'Trajet', 23000, 7.2, 304, 1.1, 5976, 28976, 'Klapptüren', 'Hässlich wie die Nacht'], ['Ford', 'Galaxy Ambiente', 24400, 10.1, 330, 1.3, 8383, 32783, '193 km/h'], ['Fiat', 'Ulysse', 25200, 9.2, 324, 1.3, 7635.999999999999, 32836, 'Schiebetüren'], ['Citroën', 'C8', 25400, 9.1, 324, 1.3, 7553, 32953, 'Schiebetüren'], ['Peugeot', '807 2.0', 25450, 9.1, 324, 1.3, 7553, 33003, 'Schiebetüren'], ['Renault', 'Espace 2.0 Advantage', 25500, 9.4, 291, 1.3, 7802, 33302, 'kleiner Kofferraum'], ['Chrysler', 'Voyager Family', 25900, 10.1, 660, 1.3, 8383, 34283, 'Gegenübersitzen'], ['VW', 'Multivan Startline', 29000, 8, 664, 1.3, 6640, 35640, 'Gegenübersitzen'], ['Lancia', 'Phedra', 30900, 6.9, 324, 1.1, 5727, 36627], ['VW', 'Sharan 2.0', 29300, 9.4, 1200, 1.3, 7802, 37102], ['Mercedes-Benz', 'Viano Lang', 33150, 8.9, 730, 1.1, 7387, 40537], [], ['Hyundai', 'H-1 Travel', 20400, 8.3, '', 1.1, 6889.000000000001, 27289], ['Ford', 'Transit Cityline', 19611, 7, '', 1.1, 5810, 25421], ['Opel', 'Vivaro', 19660, 7.7, '', 1.1, 6391, 26051], ['Renault', 'Trafic', '', '', '', 1.1, 0, 0], ['Nissan', 'Primastar', '', '', '', 1.1, 0, 0], ['Citroën', 'Jumper', '', '', '', 1.1, 0, 0], ['Peugeot', 'Boxer', 19490, 7, '', 1.1, 5810, 25300], ['Fiat', 'Ducato', 19390, 7.3, '', 1.1, 6059, 25449]] },
-              }),
+              get: ({ spreadsheetId }) => (TEST_VALUES[spreadsheetId]),
             },
           },
         }),
@@ -91,6 +141,58 @@ describe('Google Sheets Tests (mocked)', () => {
     assert.notEqual(result.body.length, 0);
     assert.equal(result.body[0].Modell, 'Trajet');
     assert.ok(result.body[0].Preis);
+  }).timeout(15000);
+
+  it('Returns 404 for unknown sheet', async () => {
+    const result = await extract(
+      new URL('https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true'),
+      {
+        GOOGLE_DOCS2MD_CLIENT_ID: 'fake',
+        GOOGLE_DOCS2MD_CLIENT_SECRET: 'fake',
+        GOOGLE_DOCS2MD_REFRESH_TOKEN: 'fake',
+        sheet: 'foo',
+      },
+    );
+    assert.equal(result.statusCode, 404);
+  }).timeout(15000);
+
+  it('Returns 404 for sheets with no helix-default', async () => {
+    const result = await extract(
+      new URL('https://docs.google.com/spreadsheets/d/3333333333333333333/edit?ouid=107837958797411838063&usp=sheets_home&ths=true'),
+      {
+        GOOGLE_DOCS2MD_CLIENT_ID: 'fake',
+        GOOGLE_DOCS2MD_CLIENT_SECRET: 'fake',
+        GOOGLE_DOCS2MD_REFRESH_TOKEN: 'fake',
+      },
+    );
+    assert.equal(result.statusCode, 404);
+  }).timeout(15000);
+
+  it('Returns first sheet if no helix-sheets', async () => {
+    const result = await extract(
+      new URL('https://docs.google.com/spreadsheets/d/2222222222222222222/edit?ouid=107837958797411838063&usp=sheets_home&ths=true'),
+      {
+        GOOGLE_DOCS2MD_CLIENT_ID: 'fake',
+        GOOGLE_DOCS2MD_CLIENT_SECRET: 'fake',
+        GOOGLE_DOCS2MD_REFRESH_TOKEN: 'fake',
+      },
+    );
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, [{ Code: 'JP', Country: 'Japan', Number: '81' }]);
+  }).timeout(15000);
+
+  it('Returns correct sheet', async () => {
+    const result = await extract(
+      new URL('https://docs.google.com/spreadsheets/d/3333333333333333333/edit?ouid=107837958797411838063&usp=sheets_home&ths=true'),
+      {
+        GOOGLE_DOCS2MD_CLIENT_ID: 'fake',
+        GOOGLE_DOCS2MD_CLIENT_SECRET: 'fake',
+        GOOGLE_DOCS2MD_REFRESH_TOKEN: 'fake',
+        sheet: 'countries',
+      },
+    );
+    assert.equal(result.statusCode, 200);
+    assert.deepEqual(result.body, [{ Code: 'CH', Country: 'Switzerland', Number: '41' }]);
   }).timeout(15000);
 
   it('Fails (in a good way) for mocked Google Sheets', async () => {

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -46,18 +46,20 @@ describe('Post-Deploy Tests', () => {
   }).timeout(10000);
 
   it('Excel Embed (without tables)', async () => {
-    console.log('Trying', 'https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx?share=Edoi88tLKLpDsKzSfL-pcJYB2lIo7UKooYWnjm3w2WRrsA&email=helix%40adobe.com&e=tD623x');
+    const url = 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a';
+    console.log('Trying', url);
 
     await chai
       .request('https://adobeioruntime.net/')
-      .get(`${getbaseurl()}/https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx?share=Edoi88tLKLpDsKzSfL-pcJYB2lIo7UKooYWnjm3w2WRrsA&email=helix%40adobe.com&e=tD623x`)
+      .get(`${getbaseurl()}/${url}`)
       .then((response) => {
-        // console.log(response.body);
+        // console.log(response);
         expect(response).to.have.status(200);
         expect(response).to.be.json;
         expect(response.body).to.be.an('array').that.deep.includes({
-          project: 'Helix',
-          created: 2018,
+          Country: 'Japan',
+          Code: 'JP',
+          Number: 3,
         });
       }).catch((e) => {
         throw e;
@@ -65,24 +67,20 @@ describe('Post-Deploy Tests', () => {
   }).timeout(10000);
 
   it('Excel Embed (with tables)', async () => {
-    console.log('Trying', 'https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx?share=Edz_l4D0BghJjLkIfyZCB7sBLaBhySyT5An7fPHVS6CFuA&email=helix%40adobe.com&e=e5ziwf');
+    const url = 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx?d=w6911fff4a52a4b3fb80560d8785adfa3&csf=1&web=1&e=fkkA2a';
+    console.log('Trying', url);
 
     await chai
       .request('https://adobeioruntime.net/')
-      .get(`${getbaseurl()}/https://adobe-my.sharepoint.com/personal/trieloff_adobe_com/_layouts/15/guestaccess.aspx?share=Edz_l4D0BghJjLkIfyZCB7sBLaBhySyT5An7fPHVS6CFuA&email=helix%40adobe.com&e=e5ziwf`)
+      .get(`${getbaseurl()}?src=${encodeURIComponent(url)}&sheet=tables&table=0`)
       .then((response) => {
+        console.log(response);
         expect(response).to.have.status(200);
         expect(response).to.be.json;
         expect(response.body).to.be.an('array').that.deep.includes({
-          Column1: 'Klapptüren',
-          Gesamtkosten: 28976,
-          Hersteller: 'Hyundai',
-          Kofferraum: 304,
-          Modell: 'Trajet',
-          Preis: 23000,
-          Preis2: 1.1,
-          Verbrauch: 7.2,
-          'Verbrauch pro Jahr': 5976,
+          A: 112,
+          B: 224,
+          C: 135,
         });
       }).catch((e) => {
         throw e;
@@ -90,15 +88,17 @@ describe('Post-Deploy Tests', () => {
   }).timeout(10000);
 
   it('Google Sheets Embed', async () => {
-    console.log('Trying', `https://adobeioruntime.net/${getbaseurl()}/https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true`);
-
+    const url = 'https://docs.google.com/spreadsheets/d/1KP2-ty18PLmHMduBX-ZOlHUpNCk6uB1Q1i__l3scoTM/view';
+    console.log('Trying', url);
     await chai
       .request('https://adobeioruntime.net/')
-      .get(`${getbaseurl()}/https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true`)
+      .get(`${getbaseurl()}/${url}`)
       .then((response) => {
         expect(response).to.be.json;
         expect(response.body).to.be.an('array').that.deep.includes({
-          Hersteller: 'Hyundai', Modell: 'Trajet', Preis: 23000, Verbrauch: 7.2, Kofferraum: 304, Preis2: 1.1, 'Verbrauch pro Jahr': 5976, Gesamtkosten: 28976,
+          Country: 'Japan',
+          Code: 'JP',
+          Number: 3,
         });
         expect(response).to.have.status(200);
       }).catch((e) => {
@@ -107,24 +107,16 @@ describe('Post-Deploy Tests', () => {
   }).timeout(10000);
 
   it('Google Sheets Embed with Query Builder', async () => {
-    console.log('Trying', `https://adobeioruntime.net/${getbaseurl()}/https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true`);
+    const url = 'https://docs.google.com/spreadsheets/d/1KP2-ty18PLmHMduBX-ZOlHUpNCk6uB1Q1i__l3scoTM/edit?hlx_property=Code&hlx_property.value=DE';
+    console.log('Trying', url);
 
     await chai
       .request('https://adobeioruntime.net/')
-      .get(`${getbaseurl()}/https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true&hlx_property=Hersteller&hlx_property.value=Ford`)
+      .get(`${getbaseurl()}/${url}`)
       .then((response) => {
+        console.log(response.body);
         expect(response).to.be.json;
-        expect(response.body).to.be.an('array').that.deep.includes({
-          Gesamtkosten: 32783,
-          Hersteller: 'Ford',
-          Kofferraum: 330,
-          Modell: 'Galaxy Ambiente',
-          Preis: 24400,
-          Preis2: 1.3,
-          Verbrauch: 10.1,
-          'Verbrauch pro Jahr': 8383,
-        });
-        expect(response.body).to.have.lengthOf(2);
+        expect(response.body).to.be.an('array').that.eql([{ Code: 'DE', Country: 'Germany', Number: 5 }]);
         expect(response).to.have.status(200);
       }).catch((e) => {
         throw e;
@@ -132,26 +124,17 @@ describe('Post-Deploy Tests', () => {
   }).timeout(10000);
 
   it('Google Sheets Embed with Query Builder (alternative syntax)', async () => {
-    const src = 'https://docs.google.com/spreadsheets/d/1IX0g5P74QnHPR3GW1AMCdTk_-m954A-FKZRT2uOZY7k/edit?ouid=107837958797411838063&usp=sheets_home&ths=true';
-    const url = `${getbaseurl()}?src=${encodeURIComponent(src)}&hlx_property=Hersteller&hlx_property.value=Ford`;
+    const src = 'https://docs.google.com/spreadsheets/d/1KP2-ty18PLmHMduBX-ZOlHUpNCk6uB1Q1i__l3scoTM/edit';
+    const url = `${getbaseurl()}?src=${encodeURIComponent(src)}&hlx_property=Code&hlx_property.value=DE`;
     console.log('Trying', url);
 
     await chai
       .request('https://adobeioruntime.net/')
       .get(url)
       .then((response) => {
+        console.log(response.body);
         expect(response).to.be.json;
-        expect(response.body).to.be.an('array').that.deep.includes({
-          Gesamtkosten: 32783,
-          Hersteller: 'Ford',
-          Kofferraum: 330,
-          Modell: 'Galaxy Ambiente',
-          Preis: 24400,
-          Preis2: 1.3,
-          Verbrauch: 10.1,
-          'Verbrauch pro Jahr': 8383,
-        });
-        expect(response.body).to.have.lengthOf(2);
+        expect(response.body).to.be.an('array').that.eql([{ Code: 'DE', Country: 'Germany', Number: 5 }]);
         expect(response).to.have.status(200);
       }).catch((e) => {
         throw e;


### PR DESCRIPTION
fixes #118

### changes

- the sheet inside an excel workbook or google spreadsheet can now be addressed using the `sheet` parameter. 
- only sheets having the `helix-` prefix can be addressed
- if the workbook or spreadsheet does not have any `helix-` prefixed sheets, the first one is returned.
- By default the _used ranged_ of the selected sheet is returned.
- For excel, A table can be addressed using the `table` request parameter, which can be a table name or an index. For example, `table=Table1` will return the table with the name `Table1`, `table=1` will return the second table in the sheet.
- Note that specifying a table index will result in an additional request to lookup the table names.

