### PR TITLE
feat: force http1 when invoking other runtime actions

### DIFF
--- a/src/matchers/run-query.js
+++ b/src/matchers/run-query.js
@@ -10,10 +10,14 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable camelcase */
+
+// force HTTP/1 in order to avoid issues with long-lived HTTP/2 sessions
+// on azure/kubernetes based I/O Runtime
+process.env.HELIX_FETCH_FORCE_HTTP1 = true;
 const { fetch } = require('@adobe/helix-fetch').context({
-  // force HTTP/1 in order to avoid issues with long-lived HTTP/2 sessions
-  // on azure/kubernetes based I/O Runtime
-  httpsProtocols: ['http1'],
+  httpsProtocols:
+    /* istanbul ignore next */
+    process.env.HELIX_FETCH_FORCE_HTTP1 ? ['http1'] : ['http2', 'http1'],
 });
 const { utils } = require('@adobe/helix-shared');
 

--- a/src/matchers/run-query.js
+++ b/src/matchers/run-query.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable camelcase */
-const { fetch } = require('@adobe/helix-fetch');
+const { fetch } = require('@adobe/helix-fetch').context({
+  // force HTTP/1 in order to avoid issues with long-lived HTTP/2 sessions
+  // on azure/kubernetes based I/O Runtime
+  httpsProtocols: ['http1'],
+});
 const { utils } = require('@adobe/helix-shared');
 
 async function extract(url, params, log = console) {


### PR DESCRIPTION
The upcoming/new I/O Runtime environment is Azure-based and supports HTTP/2. This might lead to
issues with long-lived HTTP/2 sessions.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
